### PR TITLE
Implement GPT and peripheral modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,10 +65,14 @@ smart_kitchen_assistant/
      - Recipe progression (e.g., next step)
      - Timer management (e.g., set/query/delete)
    - Calls relevant backend functions and forms a friendly spoken/text response
+   - `gpt_handler.py` and `whisper_handler.py` provide simple wrappers for the
+     OpenAI APIs used to interpret user input.
 
 5. Finally:
    - Add `tts_handler.py` using pyttsx3 or edge-tts
    - Add `esp_bridge.py` for ESP32 (e.g., send responses over MQTT or HTTP)
+   - These modules are now included for basic text-to-speech output and a
+     minimal HTTP bridge to an ESP32 device.
 
 ## ✅ Goals:
 - Fully modular and testable backend
@@ -89,3 +93,7 @@ In another terminal run the UI:
 ```bash
 streamlit run smart_kitchen_assistant/ui/main.py
 ```
+
+Some features such as GPT and Whisper require an OpenAI API key. Set
+`OPENAI_API_KEY` in your environment before starting the server if you wish to
+use them.

--- a/smart_kitchen_assistant/backend/__init__.py
+++ b/smart_kitchen_assistant/backend/__init__.py
@@ -1,0 +1,15 @@
+"""Backend utilities for the Smart Kitchen Assistant."""
+
+from .timer_manager import TimerManager
+from .gpt_handler import GPTHandler
+from .tts_handler import TTSHandler
+from .whisper_handler import WhisperHandler
+from .esp_bridge import ESPBridge
+
+__all__ = [
+    "TimerManager",
+    "GPTHandler",
+    "TTSHandler",
+    "WhisperHandler",
+    "ESPBridge",
+]

--- a/smart_kitchen_assistant/backend/esp_bridge.py
+++ b/smart_kitchen_assistant/backend/esp_bridge.py
@@ -1,0 +1,16 @@
+import requests
+from typing import Optional
+
+class ESPBridge:
+    """Send messages to an ESP32 device over HTTP."""
+
+    def __init__(self, base_url: str):
+        self.base_url = base_url.rstrip('/')
+
+    def send_message(self, path: str, payload: Optional[dict] = None) -> bool:
+        url = f"{self.base_url}/{path.lstrip('/')}"
+        try:
+            resp = requests.post(url, json=payload or {})
+            return resp.status_code == 200
+        except Exception:
+            return False

--- a/smart_kitchen_assistant/backend/gpt_handler.py
+++ b/smart_kitchen_assistant/backend/gpt_handler.py
@@ -1,0 +1,24 @@
+import openai
+from typing import Dict, Any
+
+# Simple GPT prompt handler. In a real system you'd use more complex prompting
+# and maintain conversation state. Here we just forward the message and optional
+# function definitions to the OpenAI API and return the response text or
+# function call data.
+
+class GPTHandler:
+    def __init__(self, api_key: str):
+        openai.api_key = api_key
+        self.model = "gpt-3.5-turbo"
+
+    def chat(self, user_message: str, functions: Dict[str, Any] | None = None) -> Dict[str, Any]:
+        messages = [{"role": "user", "content": user_message}]
+        kwargs: Dict[str, Any] = {"model": self.model, "messages": messages}
+        if functions:
+            kwargs["functions"] = functions
+        response = openai.ChatCompletion.create(**kwargs)
+        choice = response.choices[0].message
+        result = {"content": choice.get("content")}
+        if "function_call" in choice:
+            result["function_call"] = choice.function_call
+        return result

--- a/smart_kitchen_assistant/backend/tts_handler.py
+++ b/smart_kitchen_assistant/backend/tts_handler.py
@@ -1,0 +1,11 @@
+import pyttsx3
+
+class TTSHandler:
+    """Simple text-to-speech handler using pyttsx3."""
+
+    def __init__(self):
+        self.engine = pyttsx3.init()
+
+    def speak(self, text: str) -> None:
+        self.engine.say(text)
+        self.engine.runAndWait()

--- a/smart_kitchen_assistant/backend/whisper_handler.py
+++ b/smart_kitchen_assistant/backend/whisper_handler.py
@@ -1,0 +1,20 @@
+import io
+import requests
+
+class WhisperHandler:
+    """Transcribe audio using OpenAI Whisper API."""
+
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+
+    def transcribe(self, audio_bytes: bytes, filename: str = "audio.wav") -> str:
+        files = {"file": (filename, io.BytesIO(audio_bytes), "audio/wav")}
+        headers = {"Authorization": f"Bearer {self.api_key}"}
+        response = requests.post(
+            "https://api.openai.com/v1/audio/transcriptions",
+            headers=headers,
+            files=files,
+            data={"model": "whisper-1"},
+        )
+        response.raise_for_status()
+        return response.json().get("text", "")

--- a/smart_kitchen_assistant/requirements.txt
+++ b/smart_kitchen_assistant/requirements.txt
@@ -3,3 +3,6 @@ uvicorn
 pydantic
 streamlit
 requests
+
+openai
+pyttsx3


### PR DESCRIPTION
## Summary
- implement GPT handler for OpenAI API
- add simple text-to-speech and ESP bridge modules
- include Whisper transcription helper
- update backend exports
- note new modules and API key in README
- update requirements

## Testing
- `pip install -r smart_kitchen_assistant/requirements.txt`
- `python -m py_compile smart_kitchen_assistant/backend/*.py`
- `uvicorn smart_kitchen_assistant.backend.app:app --reload`
- `streamlit run smart_kitchen_assistant/ui/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6883bb4524dc8332bf0f0200f63c5e44