### PR TITLE
Add TimerManager tests and pytest instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,11 @@ streamlit run smart_kitchen_assistant/ui/main.py
 Some features such as GPT and Whisper require an OpenAI API key. Set
 `OPENAI_API_KEY` in your environment before starting the server if you wish to
 use them.
+
+## Running tests
+
+From the repository root simply run:
+
+```bash
+pytest
+```

--- a/smart_kitchen_assistant/requirements.txt
+++ b/smart_kitchen_assistant/requirements.txt
@@ -6,3 +6,4 @@ requests
 
 openai
 pyttsx3
+pytest

--- a/tests/test_timer_manager.py
+++ b/tests/test_timer_manager.py
@@ -1,0 +1,38 @@
+import time
+from datetime import timedelta
+
+import importlib.util
+from pathlib import Path
+
+BACKEND_DIR = Path(__file__).resolve().parents[1] / "smart_kitchen_assistant" / "backend"
+spec = importlib.util.spec_from_file_location(
+    "timer_manager", BACKEND_DIR / "timer_manager.py"
+)
+timer_manager = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(timer_manager)
+TimerManager = timer_manager.TimerManager
+
+
+def test_add_and_query_timer():
+    mgr = TimerManager()
+    mgr.add_timer('eggs', 2)
+    timers = mgr.get_all_timers()
+    assert 'eggs' in timers
+    remaining = timers['eggs']
+    assert timedelta(seconds=0) < remaining <= timedelta(seconds=2)
+
+
+def test_remove_timer():
+    mgr = TimerManager()
+    mgr.add_timer('tea', 5)
+    assert mgr.remove_timer('tea') is True
+    assert 'tea' not in mgr.get_all_timers()
+    assert mgr.remove_timer('tea') is False
+
+
+def test_timer_expiration():
+    mgr = TimerManager()
+    mgr.add_timer('quick', 1)
+    time.sleep(1.1)
+    timers = mgr.get_all_timers()
+    assert 'quick' not in timers


### PR DESCRIPTION
## Summary
- add `pytest` as a dependency
- document how to run tests
- add `tests/test_timer_manager.py` covering timer add/query/remove

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c35ec9a48332bfd924d45542e4ea