### PR TITLE
Fix UI sleep call

### DIFF
--- a/smart_kitchen_assistant/ui/main.py
+++ b/smart_kitchen_assistant/ui/main.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import requests
 from datetime import datetime
+import time
 
 API_BASE = "http://localhost:8000"
 
@@ -41,4 +42,4 @@ while True:
         ])
     else:
         timers_container.write("No active timers")
-    st.sleep(1)
+    time.sleep(1)


### PR DESCRIPTION
## Summary
- fix the Streamlit UI loop to use `time.sleep`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883c73519208332b0f1d8cc72e605f8